### PR TITLE
Add jinja-html support (close #8)

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -35,6 +35,7 @@ const languageSupport = [
   'jinja',
   'j2',
   'asp',
+  'jinja-html',
 ];
 
 const provideCompletionItems = (document, position) => {


### PR DESCRIPTION
I can confirm that [this issue](https://github.com/hossaini310/bootstrap-intellisense/issues/8) regarding lack of support for `jinja-html` files is still a problem.

I cannot test my changes locally at the moment but glancing at the code leads me to believe that this will enable proper support for `jinja-html` files.